### PR TITLE
Tag search support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: git://github.com/birdfeed/kagu.git
-  revision: e5b226fd3f8a1708e863611757af73691be7f36c
+  revision: bf280752c28ba533d192aa139ba1ded18ef6a142
   specs:
-    kagu (0.0.21)
+    kagu (0.0.24)
       activerecord
       activesupport
       devise

--- a/lib/api/endpoints/experiment.rb
+++ b/lib/api/endpoints/experiment.rb
@@ -44,15 +44,15 @@ module API
         status 200
 
         predicate = if declared_params.key?(:tags)
-          ::Experiment.by_tags(declared_params[:tags])
-            .records
-        else
-          ::Experiment
-        end
+                      ::Experiment.by_tags(declared_params[:tags])
+                                  .records
+                    else
+                      ::Experiment
+                    end
 
         experiments = predicate
-          .where(declared_params.except(:tags).to_h)
-          .accessible_by(current_ability)
+                      .where(declared_params.except(:tags).to_h)
+                      .accessible_by(current_ability)
 
         present(experiments, with: Entities::Collection)
       end

--- a/lib/api/endpoints/sample.rb
+++ b/lib/api/endpoints/sample.rb
@@ -46,11 +46,26 @@ module API
       end
 
       desc 'Retrieve a list of samples'
+      params do
+        optional :tags, type: String, desc: 'Whitespace delimited string of '\
+          'tags.'
+      end
       get authorize: [:read, ::Sample] do
         status 200
 
+        predicate = if declared_params.key?(:tags)
+                      ::Sample.by_tags(declared_params[:tags])
+                              .records
+                    else
+                      ::Sample
+                    end
+
+        samples = predicate
+                  .where(declared_params.except(:tags).to_h)
+                  .accessible_by(current_ability)
+
         present(
-          ::Sample.all, with: Entities::Collection
+          samples, with: Entities::Collection
         )
       end
 

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -9,6 +9,7 @@ module API
     autoload :Experiment
     autoload :Sample
     autoload :Score
+    autoload :Tag
     autoload :User
   end
 end

--- a/lib/api/entities/base.rb
+++ b/lib/api/entities/base.rb
@@ -21,13 +21,16 @@ module API
         # TODO: L29 is awful
         # rubocop:disable Metrics/MethodLength
         def generate_eval(name, meta)
+          return unless API::Entities.constants.include?(
+            name.singularize.camelize.to_sym
+          )
+
           case meta
           when ActiveRecord::Reflection::BelongsToReflection
             "property :#{name.singularize}, "\
               "decorator: API::Entities::#{name.camelize}"
           when ActiveRecord::Reflection::HasManyReflection,
               ActiveRecord::Reflection::HasAndBelongsToManyReflection
-            return nil if name == 'tags'
             "collection :#{meta.plural_name}, "\
               'decorator: API::Entities::Collection'
           else ''

--- a/lib/api/entities/base.rb
+++ b/lib/api/entities/base.rb
@@ -19,7 +19,7 @@ module API
         private
 
         # TODO: L29 is awful
-        # rubocop:disable Method/MethodLength
+        # rubocop:disable Metrics/MethodLength
         def generate_eval(name, meta)
           case meta
           when ActiveRecord::Reflection::BelongsToReflection
@@ -33,7 +33,7 @@ module API
           else ''
           end
         end
-        # rubocop:enable Method/MethodLength
+        # rubocop:enable Metrics/MethodLength
       end
 
       link :self do |opts|

--- a/lib/api/entities/experiment.rb
+++ b/lib/api/entities/experiment.rb
@@ -6,6 +6,8 @@ module API
       property :name
       property :repeats
       property :active
+
+      collection :tags, decorator: API::Entities::Tag
     end
   end
 end

--- a/lib/api/entities/sample.rb
+++ b/lib/api/entities/sample.rb
@@ -9,7 +9,7 @@ module API
       property :private
       property :hypothesis
 
-      # TODO: Add tags property
+      collection :tags, decorator: API::Entities::Tag
     end
   end
 end

--- a/lib/api/entities/tag.rb
+++ b/lib/api/entities/tag.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module API
+  module Entities
+    class Tag < Base
+      property :name
+    end
+  end
+end

--- a/lib/api/helpers.rb
+++ b/lib/api/helpers.rb
@@ -4,5 +4,6 @@ module API
     extend ActiveSupport::Autoload
 
     autoload :Doorkeeper
+    autoload :Params
   end
 end

--- a/lib/api/helpers/params.rb
+++ b/lib/api/helpers/params.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+module API
+  module Helpers
+    module Params
+      def declared_params
+        declared(params, include_missing: false)
+      end
+    end
+  end
+end

--- a/lib/api/root.rb
+++ b/lib/api/root.rb
@@ -6,6 +6,7 @@ module API
   class Root < Grape::API
     helpers Doorkeeper::Grape::Helpers
     helpers ::API::Helpers::Doorkeeper
+    helpers ::API::Helpers::Params
 
     format :json
     formatter :json, Grape::Formatter::Roar

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 namespace :elasticsearch do
   desc 'Force recreate indices for all taggable entities'
   task force_reindex: :environment do

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -1,0 +1,14 @@
+namespace :elasticsearch do
+  desc 'Force recreate indices for all taggable entities'
+  task force_reindex: :environment do
+    Tag.taggable_kinds.values.each do |t|
+      t.__elasticsearch__.create_index!(force: true)
+      t.import
+    end
+  end
+
+  desc 'Update all records in ES'
+  task update_all: :environment do
+    Tag.taggable_kinds.values.each(&:import)
+  end
+end


### PR DESCRIPTION
[#139764995]

- Experiments and samples can now take an optional `tags` query parameter with a whitespace delimited string of tags to be delegated to ElasticSearch