### PR TITLE
142475501 organizations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,3 +20,6 @@ Style/MultilineIfModifier:
 
 Style/RegexpLiteral:
   Enabled: false
+
+Metrics/ClassLength:
+  Max: 150

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: git://github.com/birdfeed/kagu.git
-  revision: c3e91bb7891d0938091e3264004bd8b3ba5b2a2b
+  revision: f47350ba01ec0b0e2091d1878927441ba08561ec
   specs:
-    kagu (0.0.25)
+    kagu (0.1.0)
       activerecord
       activesupport
       devise

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: git://github.com/birdfeed/kagu.git
-  revision: bf280752c28ba533d192aa139ba1ded18ef6a142
+  revision: c3e91bb7891d0938091e3264004bd8b3ba5b2a2b
   specs:
-    kagu (0.0.24)
+    kagu (0.0.25)
       activerecord
       activesupport
       devise
@@ -267,8 +267,9 @@ GEM
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
       uber (< 0.2.0)
-    responders (2.3.0)
-      railties (>= 4.2.0, < 5.1)
+    responders (2.4.0)
+      actionpack (>= 4.2.0, < 5.3)
+      railties (>= 4.2.0, < 5.3)
     roar (1.1.0)
       representable (~> 3.0.0)
     rspec (3.5.0)

--- a/lib/api/endpoints.rb
+++ b/lib/api/endpoints.rb
@@ -5,6 +5,7 @@ module API
 
     autoload :Authorize
     autoload :Experiment
+    autoload :Organization
     autoload :Sample
     autoload :Score
     autoload :User

--- a/lib/api/endpoints/application.rb
+++ b/lib/api/endpoints/application.rb
@@ -63,7 +63,7 @@ module API
         app = Doorkeeper::Application.accessible_by(current_ability)
                                      .find(declared_params[:id])
 
-        app.update_attributes(declared_params.except(:id).to_h)
+        app.update_attributes(declared_hash.except(:id))
         nil
       end
     end

--- a/lib/api/endpoints/application.rb
+++ b/lib/api/endpoints/application.rb
@@ -8,16 +8,10 @@ module API
       desc 'Create an application'
       route_setting :scopes, %(administrator)
       params do
-        requires :name, type: String, desc: 'Application name',
-                        documentation: {
-                          param_type: 'body'
-                        }
+        requires :name, type: String, desc: 'Application name'
         requires :redirect_uri,
                  type: String,
-                 desc: 'OAuth redirect URI (must be HTTPS)',
-                 documentation: {
-                   param_type: 'body'
-                 }
+                 desc: 'OAuth redirect URI (must be HTTPS)'
       end
       put authorize: [:write, Doorkeeper::Application] do
         status 201
@@ -56,20 +50,11 @@ module API
       desc 'Update an application'
       route_setting :scopes, %(administrator researcher)
       params do
-        requires :id, type: Integer, desc: 'Application ID',
-                      documentation: {
-                        param_type: 'body'
-                      }
-        optional :name, type: String, desc: 'Application name',
-                        documentation: {
-                          param_type: 'body'
-                        }
+        requires :id, type: Integer, desc: 'Application ID'
+        optional :name, type: String, desc: 'Application name'
         optional :redirect_uri,
                  type: String,
-                 desc: 'OAuth redirect URI (must be HTTPS)',
-                 documentation: {
-                   param_type: 'body'
-                 }
+                 desc: 'OAuth redirect URI (must be HTTPS)'
       end
       post '/:id', authorize: [:write, Doorkeeper::Application] do
         status 204

--- a/lib/api/endpoints/experiment.rb
+++ b/lib/api/endpoints/experiment.rb
@@ -15,7 +15,7 @@ module API
 
         present(
           ::Experiment.create(
-            declared(params).merge(user_id: current_user.id).to_h
+            declared_hash.merge(user_id: current_user.id)
           ), with: Entities::Experiment
         )
       end
@@ -28,7 +28,7 @@ module API
         status 200
 
         present(
-          ::Experiment.find(declared(params)[:id]),
+          ::Experiment.find(declared_params[:id]),
           with: Entities::Experiment
         )
       end
@@ -57,7 +57,7 @@ module API
       end
       delete '/:id', authorize: [:write, ::Experiment] do
         status 204
-        ::Experiment.delete(declared(params)[:id])
+        ::Experiment.delete(declared_params[:id])
       end
 
       desc 'Update an experiment'
@@ -78,7 +78,7 @@ module API
 
         # Update regular attributes first
         experiment.update_attributes(
-          declared_params.except(:organization_id).to_h
+          declared_hash.except(:organization_id)
         )
 
         # Append organization if present

--- a/lib/api/endpoints/experiment.rb
+++ b/lib/api/endpoints/experiment.rb
@@ -43,16 +43,9 @@ module API
       get authorize: [:read, ::Experiment] do
         status 200
 
-        predicate = if declared_params.key?(:tags)
-                      ::Experiment.by_tags(declared_params[:tags])
-                                  .records
-                    else
-                      ::Experiment
-                    end
-
-        experiments = predicate
-                      .where(declared_params.except(:tags).to_h)
-                      .accessible_by(current_ability)
+        experiments = Kagu::Query::Elastic.for(::Experiment).search(
+          declared_hash.extract!('tags')
+        ).where(declared_hash).accessible_by(current_ability)
 
         present(experiments, with: Entities::Collection)
       end

--- a/lib/api/endpoints/organization.rb
+++ b/lib/api/endpoints/organization.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+module API
+  module Endpoints
+    class Organization < Grape::API
+      resource :organizations
+      authorize_routes!
+
+      desc 'Create an organization'
+      route_setting :scopes, %w(administrator researcher)
+      params do
+        requires :name, type: String, desc: 'Name of organization',
+                        documentation: { param_type: 'body' }
+      end
+      put do
+        status 201
+
+        new_org = ::Organization.create(declared_params.to_h)
+        new_org.users << current_user
+        new_org.save
+
+        present(new_org, with: Entities::Organization)
+      end
+
+      desc 'List organizations'
+      route_setting :scopes, %w(administrator researcher participant)
+      params do
+        optional :name, type: String, desc: 'Name of the organization'
+        optional :tags, type: String, desc: 'Whitespace delimited string of '\
+          'tags.'
+      end
+      get authorize: [:read, ::Organization] do
+        status 200
+
+        predicate = if declared_params.key?(:tags)
+                      ::Organization.by_tags(declared_params[:tags])
+                                    .records
+                    else
+                      ::Organization
+                    end
+
+        organizations = predicate
+                        .where(declared_params.except(:tags).to_h)
+                        .accessible_by(current_ability)
+
+        present(organizations, with: Entities::Collection)
+      end
+
+      desc 'Retrieve an organization by ID'
+      route_setting :scopes, %w(administrator researcher participant)
+      params do
+        requires :id, type: String, desc: 'ID of organization'
+      end
+      get '/:id', authorize: [:write, ::Organization] do
+        status 200
+
+        present(::Organization.accessible_by(current_ability).find(
+                  declared_params[:id]
+        ), with: Entities::Organization)
+      end
+
+      desc 'Update an organization'
+      route_setting :scopes, %w(administrator researcher)
+      params do
+        requires :id, type: String, desc: 'ID of organization'
+        optional :name, type: String, desc: 'Name of organization',
+                        documentation: { param_type: 'body' }
+      end
+      post '/:id', authorize: [:write, ::Organization] do
+        status 200
+
+        org = ::Organization.accessible_by(current_ability)
+                            .find(declared_params[:id])
+        org.update_attributes(declared_params.to_h)
+        org.save
+
+        present(org, with: Entities::Organization)
+      end
+    end
+  end
+end

--- a/lib/api/endpoints/organization.rb
+++ b/lib/api/endpoints/organization.rb
@@ -14,7 +14,7 @@ module API
       put do
         status 201
 
-        new_org = ::Organization.create(declared_params.to_h)
+        new_org = ::Organization.create(declared_hash)
         new_org.users << current_user
         new_org.save
 
@@ -63,7 +63,7 @@ module API
 
         org = ::Organization.accessible_by(current_ability)
                             .find(declared_params[:id])
-        org.update_attributes(declared_params.to_h)
+        org.update_attributes(declared_hash)
         org.save
 
         present(org, with: Entities::Organization)

--- a/lib/api/endpoints/organization.rb
+++ b/lib/api/endpoints/organization.rb
@@ -31,16 +31,9 @@ module API
       get authorize: [:read, ::Organization] do
         status 200
 
-        predicate = if declared_params.key?(:tags)
-                      ::Organization.by_tags(declared_params[:tags])
-                                    .records
-                    else
-                      ::Organization
-                    end
-
-        organizations = predicate
-                        .where(declared_params.except(:tags).to_h)
-                        .accessible_by(current_ability)
+        organizations = Kagu::Query::Elastic.for(::Organization).search(
+          declared_hash.extract!('tags')
+        ).where(declared_hash).accessible_by(current_ability)
 
         present(organizations, with: Entities::Collection)
       end

--- a/lib/api/endpoints/sample.rb
+++ b/lib/api/endpoints/sample.rb
@@ -24,12 +24,9 @@ module API
         )
 
         present(
-          ::Sample.create(
-            declared(params).except(:file)
-                            .merge(s3_url: s3_url, user_id: current_user.id)
-                            .to_h
-          ), with: Entities::Sample
-        )
+          ::Sample.create(declared_hash.except(:file).merge(
+            s3_url: s3_url, user_id: current_user.id
+        )), with: Entities::Sample)
       end
 
       desc 'Retrieve a sample'
@@ -40,7 +37,7 @@ module API
         status 200
 
         present(
-          ::Sample.find(declared(params)[:id]),
+          ::Sample.find(declared_params[:id]),
           with: Entities::Sample
         )
       end
@@ -82,7 +79,7 @@ module API
         sample =
           ::Sample.accessible_by(current_ability)
                   .find(declared_params[:id])
-        sample.update_attributes(declared_params.to_h)
+        sample.update_attributes(declared_hash)
         sample.save
         present(sample, with: Entities::Sample)
       end

--- a/lib/api/endpoints/sample.rb
+++ b/lib/api/endpoints/sample.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 module API
   module Endpoints
-    # rubocop:disable Metrics/ClassLength
     class Sample < Grape::API
       resource :samples
       authorize_routes!
@@ -9,27 +8,11 @@ module API
       desc 'Record a sample'
       route_setting :scopes, %w(administrator researcher)
       params do
-        requires :name, type: String, desc: 'name of sample',
-                        documentation: {
-                          param_type: 'body'
-                        }
-        requires :private, type: Boolean, desc: 'flag for sample sharing',
-                           documentation: {
-                             param_type: 'body'
-                           }
+        requires :name, type: String, desc: 'name of sample'
         requires :file, type: File,
-                        desc: 'audio sample, to be uploaded to s3',
-                        documentation: {
-                          dataType: 'body'
-                        }
-        requires :low_label, type: String, desc: 'Label for low bound',
-                             documentation: {
-                               param_type: 'body'
-                             }
-        requires :high_label, type: String, desc: 'Label for upper bound',
-                              documentation: {
-                                param_type: 'body'
-                              }
+                        desc: 'audio sample, to be uploaded to s3'
+        requires :low_label, type: String, desc: 'Label for low bound'
+        requires :high_label, type: String, desc: 'Label for upper bound'
       end
       put authorize: [:write, ::Sample] do
         status 201
@@ -93,25 +76,14 @@ module API
       end
       delete '/:id', authorize: [:write, ::Sample] do
         status 204
-
         ::Sample.delete(declared(params)[:id])
       end
 
       desc 'Update a sample'
       route_setting :scopes, %w(administrator researcher)
       params do
-        requires :id, type: Integer, desc: 'ID of sample to be updated',
-                      documentation: {
-                        param_type: 'body'
-                      }
-        optional :name, type: String, desc: 'Name of sample',
-                        documentation: {
-                          param_type: 'body'
-                        }
-        optional :private, type: Boolean, desc: 'Flag for sample sharing',
-                           documentation: {
-                             param_type: 'body'
-                           }
+        requires :id, type: Integer, desc: 'ID of sample to be updated'
+        optional :name, type: String, desc: 'Name of sample'
       end
       post '/:id', authorize: [:write, ::Sample] do
         status 200
@@ -122,6 +94,29 @@ module API
         sample.update_attributes(declared_params.to_h)
         sample.save
         present(sample, with: Entities::Sample)
+      end
+
+      desc 'Associate a sample with an organization'
+      route_setting :scopes, %w(administrator researcher)
+      params do
+        requires :id, type: Integer, desc: 'Sample ID'
+        requires :organization_id, type: Integer, desc: 'Organization ID'
+      end
+      put '/:id/organizations/:organization_id' do
+        status 201
+
+        # Cannot use DSL for this since we need to do both
+        authorize! :write, ::Sample
+        authorize! :write, ::Organization
+
+        sample = ::Sample.accessible_by(current_ability)
+                         .find(declared_params[:id])
+        organization = ::Organization.accessible_by(current_ability)
+                                     .find(declared_params[:organization_id])
+
+        sample.organizations << organization
+
+        nil
       end
     end
     # rubocop:enable Metrics/ClassLength

--- a/lib/api/endpoints/sample.rb
+++ b/lib/api/endpoints/sample.rb
@@ -118,6 +118,28 @@ module API
 
         nil
       end
+
+      desc 'Disassociate a sample with an organization'
+      route_setting :scopes, %w(administrator researcher)
+      params do
+        requires :id, type: Integer, desc: 'Sample ID'
+        requires :organization_id, type: Integer, desc: 'Organization ID'
+      end
+      delete '/:id/organizations/:organization_id' do
+        status 204
+
+        authorize! :write, ::Sample
+        authorize! :write, ::Organization
+
+        sample = ::Sample.accessible_by(current_ability)
+                         .find(declared_params[:id])
+        organization = ::Organization.accessible_by(current_ability)
+                                     .find(declared_params[:organization_id])
+
+        sample.organizations.delete(organization)
+
+        nil
+      end
     end
     # rubocop:enable Metrics/ClassLength
   end

--- a/lib/api/endpoints/sample.rb
+++ b/lib/api/endpoints/sample.rb
@@ -25,8 +25,9 @@ module API
 
         present(
           ::Sample.create(declared_hash.except(:file).merge(
-            s3_url: s3_url, user_id: current_user.id
-        )), with: Entities::Sample)
+                            s3_url: s3_url, user_id: current_user.id
+          )), with: Entities::Sample
+        )
       end
 
       desc 'Retrieve a sample'

--- a/lib/api/endpoints/sample.rb
+++ b/lib/api/endpoints/sample.rb
@@ -53,20 +53,11 @@ module API
       get authorize: [:read, ::Sample] do
         status 200
 
-        predicate = if declared_params.key?(:tags)
-                      ::Sample.by_tags(declared_params[:tags])
-                              .records
-                    else
-                      ::Sample
-                    end
+        samples = Kagu::Query::Elastic.for(::Sample).search(
+          declared_hash.extract!('tags')
+        ).where(declared_hash).accessible_by(current_ability)
 
-        samples = predicate
-                  .where(declared_params.except(:tags).to_h)
-                  .accessible_by(current_ability)
-
-        present(
-          samples, with: Entities::Collection
-        )
+        present(samples, with: Entities::Collection)
       end
 
       desc 'Delete a sample'

--- a/lib/api/endpoints/score.rb
+++ b/lib/api/endpoints/score.rb
@@ -16,7 +16,7 @@ module API
         status 201
         present(
           ::Score.create(
-            declared(params).merge(user_id: current_user.id).to_h
+            declared_hash.merge(user_id: current_user.id)
           ), with: Entities::Score
         )
       end

--- a/lib/api/endpoints/score.rb
+++ b/lib/api/endpoints/score.rb
@@ -8,18 +8,9 @@ module API
       desc 'Record a score'
       route_setting :scopes, %w(participant)
       params do
-        requires :experiment_id, type: Integer, desc: 'ID of experiment',
-                                 documentation: {
-                                   param_type: 'body'
-                                 }
-        requires :sample_id, type: Integer, desc: 'ID of sample',
-                             documentation: {
-                               param_type: 'body'
-                             }
-        requires :rating, type: Float, desc: 'rating assigned to sample',
-                          documentation: {
-                            param_type: 'body'
-                          }
+        requires :experiment_id, type: Integer, desc: 'ID of experiment'
+        requires :sample_id, type: Integer, desc: 'ID of sample'
+        requires :rating, type: Float, desc: 'rating assigned to sample'
       end
       put authorize: [:write, ::Score] do
         status 201

--- a/lib/api/endpoints/user.rb
+++ b/lib/api/endpoints/user.rb
@@ -67,9 +67,8 @@ module API
       end
       post '/:id', authorize: [:write, ::User] do
         status 200
-        declared_params = declared(params, include_missing: false)
         user = ::User.accessible_by(current_ability).find(declared_params[:id])
-        user.update_attributes(declared_params.to_h)
+        user.update_attributes(declared_hash)
         user.save
 
         present(user, with: Entities::User)

--- a/lib/api/endpoints/user.rb
+++ b/lib/api/endpoints/user.rb
@@ -8,15 +8,9 @@ module API
       desc 'Create a user'
       route_setting :scopes, %(administrator)
       params do
-        requires :email, type: String, desc: 'User email address',
-                         documentation: {
-                           param_type: 'body'
-                         }
+        requires :email, type: String, desc: 'User email address'
         requires :encrypted_password, type: String,
-                                      desc: 'BCrypt hash of user password',
-                                      documentation: {
-                                        param_type: 'body'
-                                      }
+                                      desc: 'BCrypt hash of user password'
       end
       put authorize: [:write, ::User] do
         status 201
@@ -67,15 +61,9 @@ module API
                       documentation: {
                         param_type: 'body'
                       }
-        optional :email, type: String, desc: 'User email address',
-                         documentation: {
-                           param_type: 'body'
-                         }
+        optional :email, type: String, desc: 'User email address'
         optional :encrypted_password, type: String,
-                                      desc: 'BCrypt hash of user password',
-                                      documentation: {
-                                        param_type: 'body'
-                                      }
+                                      desc: 'BCrypt hash of user password'
       end
       post '/:id', authorize: [:write, ::User] do
         status 200

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -7,6 +7,7 @@ module API
     autoload :Collection
     autoload :Doorkeeper
     autoload :Experiment
+    autoload :Organization
     autoload :Sample
     autoload :Score
     autoload :Tag

--- a/lib/api/entities/organization.rb
+++ b/lib/api/entities/organization.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 module API
   module Entities
-    class Sample < Base
-      property :s3_url
+    class Organization < Base
+      property :id
       property :name
-      property :low_label
-      property :high_label
-      property :hypothesis
 
       collection :tags, decorator: API::Entities::Tag
     end

--- a/lib/api/helpers/params.rb
+++ b/lib/api/helpers/params.rb
@@ -5,6 +5,10 @@ module API
       def declared_params
         declared(params, include_missing: false)
       end
+
+      def declared_hash
+        @declared_hash ||= declared_params.to_h
+      end
     end
   end
 end

--- a/lib/api/helpers/params.rb
+++ b/lib/api/helpers/params.rb
@@ -7,7 +7,7 @@ module API
       end
 
       def declared_hash
-        @declared_hash ||= declared_params.to_h
+        @declared_hash ||= declared_params.to_h.with_indifferent_access
       end
     end
   end

--- a/lib/api/root.rb
+++ b/lib/api/root.rb
@@ -31,6 +31,7 @@ module API
 
     mount Endpoints::Application => '/applications'
     mount Endpoints::Experiment => '/experiments'
+    mount Endpoints::Organization => '/organizations'
     mount Endpoints::Sample => '/samples'
     mount Endpoints::Score => '/scores'
     mount Endpoints::User => '/users'

--- a/lib/can_strap/abilities/administrator.rb
+++ b/lib/can_strap/abilities/administrator.rb
@@ -15,6 +15,10 @@ module CanStrap
         can :write, Sample
         can :read, Sample
 
+        # Organizations
+        can :write, Organization
+        can :read, Organization
+
         # Score
         can :read, Score
 

--- a/lib/can_strap/abilities/researcher.rb
+++ b/lib/can_strap/abilities/researcher.rb
@@ -11,13 +11,13 @@ module CanStrap
         can :write, Experiment, user_id: user.id
         can :read, Experiment, user_id: user.id
 
-        # This is gross and I hate it
+        # Still relevant
         # https://github.com/ryanb/cancan/issues/957#issuecomment-32626510
-        can :write, Sample, private: false
         can :write, Sample, user_id: user.id
-
-        can :read, Sample, private: false
         can :read, Sample, user_id: user.id
+
+        can :read, Organization, users: { id: user.id }
+        can :write, Organization, users: { id: user.id }
 
         # Score (tbd)
         can :read, Score

--- a/spec/factories/doorkeeper/access_token_factory.rb
+++ b/spec/factories/doorkeeper/access_token_factory.rb
@@ -9,4 +9,10 @@ FactoryGirl.define do
     application
     resource_owner_id { FactoryGirl.create(:user).id }
   end
+
+  factory :researcher_token, class: Doorkeeper::AccessToken do 
+    token { Faker::Crypto.sha1 }
+    application
+    resource_owner_id { FactoryGirl.create(:researcher_user).id }
+  end
 end

--- a/spec/factories/organization_factory.rb
+++ b/spec/factories/organization_factory.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :organization do 
+    sequence(:name) { |n| "#{Faker::Color.color_name}-#{n}" }
+  end
+end

--- a/spec/requests/experiment_spec.rb
+++ b/spec/requests/experiment_spec.rb
@@ -99,19 +99,16 @@ describe 'Experiment CRUD', type: :request do
       end
     end
 
-    context 'with tags / elasticsearch' do
-      # Don't require ES in test, just ensure it happens
+    context 'tags / with elasticsearch' do
       before do
-        allow(::Experiment).to receive(:by_tags)
-          .with(tags)
-          .and_return(OpenStruct.new(
-            records: ::Experiment.joins(:tags).where(
+        allow_any_instance_of(Kagu::Query::Elastic).to receive(:search)
+          .with('tags' => tags)
+          .and_return(::Experiment.joins(:tags).where(
               tags: { name: tags.split }
-            ) 
           ))
 
-        experiments.last(5).each do |e|
-          e.tags << 'foo'
+        experiments.last(5).each do |s|
+          s.tags << 'foo'
         end
 
         get '/v3/experiments',
@@ -122,7 +119,7 @@ describe 'Experiment CRUD', type: :request do
 
       let(:tags) { 'foo bar' }
 
-      it 'finds all the tagged records' do
+      it 'calls the adapter' do
         expect(response.code).to eql('200')
         expect(results['experiments'].count).to eql(5)
       end

--- a/spec/requests/organization_spec.rb
+++ b/spec/requests/organization_spec.rb
@@ -50,18 +50,16 @@ describe 'Organization CRUD', type: :request do
       end
     end
 
-    context 'with tags / elasticsearch' do
+    context 'tags / with elasticsearch' do
       before do
-        allow(::Organization).to receive(:by_tags)
-          .with(tags)
-          .and_return(OpenStruct.new(
-            records: ::Organization.joins(:tags).where(
+        allow_any_instance_of(Kagu::Query::Elastic).to receive(:search)
+          .with('tags' => tags)
+          .and_return(::Organization.joins(:tags).where(
               tags: { name: tags.split }
-            ) 
           ))
 
-        organizations.last(5).each do |e|
-          e.tags << 'foo'
+        organizations.last(5).each do |s|
+          s.tags << 'foo'
         end
 
         get '/v3/organizations',
@@ -72,7 +70,7 @@ describe 'Organization CRUD', type: :request do
 
       let(:tags) { 'foo bar' }
 
-      it 'finds all the tagged records' do
+      it 'calls the adapter' do
         expect(response.code).to eql('200')
         expect(results['organizations'].count).to eql(5)
       end

--- a/spec/requests/organization_spec.rb
+++ b/spec/requests/organization_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+describe 'Organization CRUD', type: :request do 
+  let(:token) { FactoryGirl.create(:researcher_token) }
+  let(:results) { JSON.parse(response.body) }
+
+  context 'PUT /organizations' do
+    before do
+      put '/v3/organizations',
+        params: { name: 'Foo Organization' },
+        headers: { 'Authorization' => "Bearer #{token.token}" }
+    end
+
+    it 'should create the organization' do
+      expect(response.code).to eql('201')
+      expect(Organization.find(results['id'])).to be_present
+    end
+  end
+
+  context 'GET /organizations' do
+    let!(:organizations) do
+      FactoryGirl.create_list(
+        :organization, 15, users: [User.find(token.resource_owner_id)]
+      ) 
+    end
+
+    let!(:not_in_orgs) { FactoryGirl.create_list(:organization, 5) }
+
+    before do
+      get '/v3/organizations', 
+        headers: { 'Authorization' => "Bearer #{token.token}" }
+    end
+
+    it 'should find organizations that I am a member of' do 
+      expect(response.code).to eql('200')
+      ids = results['organizations'].map { |x| x['id'] }
+      expect(ids).to match_array(organizations.pluck(:id))
+      expect(ids).to_not match_array(not_in_orgs.pluck(:id))
+    end
+
+    context 'by ID' do
+      before do
+        get "/v3/organizations/#{organizations.first.id}", 
+          headers: { 'Authorization' => "Bearer #{token.token}" }
+      end
+
+      it 'should find the organization' do
+        expect(response.code).to eql('200')
+        expect(results['id']).to eql(organizations.first.id) 
+      end
+    end
+
+    context 'with tags / elasticsearch' do
+      before do
+        allow(::Organization).to receive(:by_tags)
+          .with(tags)
+          .and_return(OpenStruct.new(
+            records: ::Organization.joins(:tags).where(
+              tags: { name: tags.split }
+            ) 
+          ))
+
+        organizations.last(5).each do |e|
+          e.tags << 'foo'
+        end
+
+        get '/v3/organizations',
+          params: { tags: tags }, headers: { 
+            'Authorization' => "Bearer #{token.token}" 
+          }
+      end
+
+      let(:tags) { 'foo bar' }
+
+      it 'finds all the tagged records' do
+        expect(response.code).to eql('200')
+        expect(results['organizations'].count).to eql(5)
+      end
+    end
+  end
+
+  context 'POST /organizations' do
+    let(:org) do
+      FactoryGirl.create(:organization, users: [User.find(token.resource_owner_id)])
+    end
+
+    let(:new_name) { 'foobar' }
+
+    before do
+      post "/v3/organizations/#{org.id}",
+        params: { name: new_name },
+        headers: { 'Authorization' => "Bearer #{token.token}" }
+    end
+
+    it 'should update the organization name' do
+      expect(response.code).to eql('200')
+      org.reload
+      expect(org.name).to eql(new_name)
+    end
+  end
+end

--- a/spec/requests/sample_spec.rb
+++ b/spec/requests/sample_spec.rb
@@ -63,14 +63,11 @@ describe 'Sample CRUD', type: :request do
     end
 
     context 'tags / with elasticsearch' do
-      # Don't require ES in test, just ensure it happens
       before do
-        allow(::Sample).to receive(:by_tags)
-          .with(tags)
-          .and_return(OpenStruct.new(
-            records: ::Sample.joins(:tags).where(
+        allow_any_instance_of(Kagu::Query::Elastic).to receive(:search)
+          .with('tags' => tags)
+          .and_return(::Sample.joins(:tags).where(
               tags: { name: tags.split }
-            ) 
           ))
 
         samples.last(5).each do |s|
@@ -85,7 +82,7 @@ describe 'Sample CRUD', type: :request do
 
       let(:tags) { 'foo bar' }
 
-      it 'finds all the tagged records' do
+      it 'calls the adapter' do
         expect(response.code).to eql('200')
         expect(result['samples'].count).to eql(5)
       end

--- a/spec/requests/sample_spec.rb
+++ b/spec/requests/sample_spec.rb
@@ -159,4 +159,23 @@ describe 'Sample CRUD', type: :request do
       expect(sample.organizations).to include(organization)
     end
   end
+
+  context 'DELETE /samples/:id/organizations/:organization_id' do
+    let(:sample) do
+      FactoryGirl.create(:sample, user_id: user.id, organizations: [
+        FactoryGirl.create(:organization, users: [user])
+      ])
+    end
+
+    before do
+      delete "/v3/samples/#{sample.id}/organizations/#{sample.organizations.first.id}",
+        headers: { 'Authorization' => "Bearer #{token.token}" }
+    end
+
+    it 'should disassociate the two' do
+      expect(response.code).to eql('204')
+      sample.reload
+      expect(sample.organizations).to be_empty
+    end
+  end
 end

--- a/spec/requests/sample_spec.rb
+++ b/spec/requests/sample_spec.rb
@@ -6,7 +6,6 @@ describe 'Sample CRUD', type: :request do
     "./spec/support/sample.wav", "audio/wav") }
 
   let(:token) { FactoryGirl.create(:oauth_token, resource_owner_id: user.id) }
-
   let(:result) { JSON.parse(response.body) }
   
   context 'PUT /samples' do 
@@ -15,7 +14,6 @@ describe 'Sample CRUD', type: :request do
       put '/v3/samples', 
       params: {
         name: 'name',
-        private: false,
         file: attachment,
         low_label: 'not R',
         high_label: 'R'
@@ -123,7 +121,7 @@ describe 'Sample CRUD', type: :request do
   end
 
   context 'UPDATE /samples' do
-    let!(:sample) { FactoryGirl.create(:sample, user_id: token.resource_owner_id) }
+    let(:sample) { FactoryGirl.create(:sample, user_id: token.resource_owner_id) }
 
     context 'update a sample' do
       before do
@@ -139,6 +137,26 @@ describe 'Sample CRUD', type: :request do
         expect(response.code).to eql('200')
         expect(::Sample.find(sample.id).name).to eql('new_name')
       end
+    end
+  end
+
+  context 'PUT /samples/:id/organizations/:organization_id' do
+    let(:sample) do
+      FactoryGirl.create(:sample, user_id: user.id)
+    end
+
+    let(:organization) do
+      FactoryGirl.create(:organization, users: [user])
+    end
+
+    before do
+      put "/v3/samples/#{sample.id}/organizations/#{organization.id}",
+        headers: { 'Authorization' => "Bearer #{token.token}" }
+    end
+
+    it 'should associate the two' do
+      expect(response.code).to eql('201')
+      expect(sample.organizations).to include(organization)
     end
   end
 end


### PR DESCRIPTION
- Organizations /v3/organizations to CRUD
- Associate experiment to organization by passing `organization_id` body parameter
- Associate samples to organizations via `PUT/DELETE /v3/samples/:id/organizations/:organization_id`
- Use new Elastic query object to DRY things up