### PR TITLE
144592393: Fix API presentation

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --require spec_helper
+-fd

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -10,7 +10,6 @@ module API
     autoload :Organization
     autoload :Sample
     autoload :Score
-    autoload :Tag
     autoload :User
   end
 end

--- a/lib/api/entities/collection.rb
+++ b/lib/api/entities/collection.rb
@@ -3,32 +3,43 @@ module API
   module Entities
     class Collection < Base
       class << self
-        # TODO: Find a better way to do this
-        # If `representable` or `grape-roar` change their interfaces we are SOL
-        # with a breaking change if our lockfile fails us.
         def represent(object, _options = {})
-          serializer = clone
-
-          serializer.extract_from_relation(
-            object
-          ) if object.is_a?(ActiveRecord::Relation)
-
-          serializer.new(object)
+          return super unless object.is_a?(ActiveRecord::Relation)
+          decorate_relation(object)
+          serializer_for(object)
         end
 
         protected
 
-        def extract_from_relation(relation)
-          str_klass = relation.klass.name.demodulize
+        def create_serializer(klass)
+          representer_cache[klass] = Class.new(Base)
+          representer_cache[klass].class_exec(klass.name) do |kn|
+            collection(
+              kn.demodulize.downcase.pluralize.to_sym,
+              extend: "API::Entities::#{kn.demodulize}".constantize
+            )
+          end
+        end
 
-          collection(str_klass.downcase.pluralize.to_sym,
-                     extend: "API::Entities::#{str_klass}".constantize)
-
+        def decorate_relation(relation)
           relation.class.send(
             :define_method,
-            str_klass.downcase.pluralize,
+            relation.klass.name.demodulize.downcase.pluralize,
             -> { self }
           )
+        end
+
+        def representer_cache
+          @representer_cache ||= {}
+        end
+
+        def serializer_for(object)
+          klass = object.klass
+          return representer_cache[klass]
+                 .new(object) if representer_cache.key?(klass)
+
+          create_serializer(klass)
+          representer_cache[klass].new(object)
         end
       end
     end

--- a/lib/api/entities/collection.rb
+++ b/lib/api/entities/collection.rb
@@ -2,9 +2,6 @@
 module API
   module Entities
     class Collection < Base
-      include Roar::JSON
-      include Roar::Hypermedia
-
       class << self
         # TODO: Find a better way to do this
         # If `representable` or `grape-roar` change their interfaces we are SOL
@@ -25,8 +22,7 @@ module API
           str_klass = relation.klass.name.demodulize
 
           collection(str_klass.downcase.pluralize.to_sym,
-                     extend: "API::Entities::#{str_klass}".constantize,
-                     class: relation.klass)
+                     extend: "API::Entities::#{str_klass}".constantize)
 
           relation.class.send(
             :define_method,

--- a/lib/api/entities/experiment.rb
+++ b/lib/api/entities/experiment.rb
@@ -7,7 +7,7 @@ module API
       property :repeats
       property :active
 
-      collection :tags, decorator: API::Entities::Tag
+      collection :tags { property :name }
     end
   end
 end

--- a/lib/api/entities/organization.rb
+++ b/lib/api/entities/organization.rb
@@ -5,7 +5,11 @@ module API
       property :id
       property :name
 
-      collection :tags, decorator: API::Entities::Tag
+      relation :users
+      relation :experiments
+      relation :samples
+
+      collection :tags { property :name }
     end
   end
 end

--- a/lib/api/entities/sample.rb
+++ b/lib/api/entities/sample.rb
@@ -9,7 +9,10 @@ module API
       property :high_label
       property :hypothesis
 
-      collection :tags, decorator: API::Entities::Tag
+      relation :experiments
+      relation :scores
+
+      collection :tags { property :name }
     end
   end
 end

--- a/lib/api/entities/score.rb
+++ b/lib/api/entities/score.rb
@@ -3,6 +3,10 @@ module API
   module Entities
     class Score < Base
       property :rating
+
+      relation :user
+      relation :experiment
+      relation :sample
     end
   end
 end

--- a/lib/api/entities/tag.rb
+++ b/lib/api/entities/tag.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-module API
-  module Entities
-    class Tag < Base
-      property :name
-    end
-  end
-end

--- a/lib/api/entities/user.rb
+++ b/lib/api/entities/user.rb
@@ -3,6 +3,9 @@ module API
   module Entities
     class User < Base
       property :email
+      property :id
+
+      collection :tags { property :name }
     end
   end
 end

--- a/spec/lib/api/entities/collection_spec.rb
+++ b/spec/lib/api/entities/collection_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe API::Entities::Collection do
+  context '.represent' do
+    let!(:scores) { FactoryGirl.create_list(:score, 10) }
+    let(:relation) { Score.all }
+
+    context 'relation' do
+      before { described_class.represent(relation, {}) }
+
+      it 'should decorate the relation with itself' do 
+        expect(relation).to eql(
+          relation.send(relation.klass.name.demodulize.downcase.pluralize)
+        )
+      end
+    end
+
+    context 'only operators on ActiveRecord::Relation' do
+      after { described_class.represent(double, {}) }
+
+      it 'should exit early' do 
+        expect(described_class).to_not receive(:decorate_relation)
+        expect(described_class).to_not receive(:serializer_for)
+      end
+    end
+
+    context 'caches relation classes' do
+      let(:samples) { FactoryGirl.create_list(:sample, 5) }
+      let(:other_relation) { Sample.all }
+
+      before do
+        described_class.represent(relation, {})
+        described_class.represent(other_relation, {})
+      end
+
+      it 'should have cache entries for score and sample' do
+        expect(described_class.send(:representer_cache).keys).to include(
+          ::Sample, ::Score
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/experiment_spec.rb
+++ b/spec/requests/experiment_spec.rb
@@ -124,22 +124,5 @@ describe 'Experiment CRUD', type: :request do
         expect(results['experiments'].count).to eql(5)
       end
     end
-
-    context 'with querystring filters' do 
-      before do
-        experiments.last.name = 'foobar'
-        experiments.last.save
-
-        get '/v3/experiments', params: { name: 'foobar' }, headers: { 
-          'Authorization' => "Bearer #{token.token}" 
-        }
-      end
-
-      it 'should return the correct experiments' do 
-        expect(response.code).to eql('200')
-        expect(results['experiments'].first['_links']['self']['href'])
-        .to eql("http://www.example.com/v3/experiments/#{experiments.last.id}")
-      end
-    end
   end
 end

--- a/spec/requests/experiment_spec.rb
+++ b/spec/requests/experiment_spec.rb
@@ -76,7 +76,7 @@ describe 'Experiment CRUD', type: :request do
           headers: { 'Authorization' => "Bearer #{token.token}" }
       end
 
-      let!(:result) { JSON.parse(response.body) }
+      let(:result) { JSON.parse(response.body) }
 
       it 'should retrieve an existing experiment' do
         expect(response.code).to eql('200')
@@ -99,7 +99,7 @@ describe 'Experiment CRUD', type: :request do
       end
     end
 
-    context 'with elasticsearch' do
+    context 'tags / with elasticsearch' do
       before do
         allow_any_instance_of(Kagu::Query::Elastic).to receive(:search)
           .with('tags' => tags)
@@ -122,6 +122,23 @@ describe 'Experiment CRUD', type: :request do
       it 'calls the adapter' do
         expect(response.code).to eql('200')
         expect(results['experiments'].count).to eql(5)
+      end
+    end
+
+    context 'with querystring filters' do 
+      before do
+        experiments.last.name = 'foobar'
+        experiments.last.save
+
+        get '/v3/experiments', params: { name: 'foobar' }, headers: { 
+          'Authorization' => "Bearer #{token.token}" 
+        }
+      end
+
+      it 'should return the correct experiments' do 
+        expect(response.code).to eql('200')
+        expect(results['experiments'].first['_links']['self']['href'])
+        .to eql("http://www.example.com/v3/experiments/#{experiments.last.id}")
       end
     end
   end

--- a/spec/requests/score_spec.rb
+++ b/spec/requests/score_spec.rb
@@ -24,15 +24,12 @@ describe 'Score CRUD', type: :request do
     end
 
     it 'should set the proper ids' do
-      expect(result["user"]["links"].first["href"]).to eql(
-        "http://www.example.com/v3/user/#{user.id}"
-      )
-      expect(result["experiment"]["links"].first["href"]).to eql(
-        "http://www.example.com/v3/experiment/#{experiment.id}"
-      )
-      expect(result["sample"]["links"].first["href"]).to eql(
-        "http://www.example.com/v3/sample/#{sample.id}"
-      )
+      expect(result['_embedded']["user"]["id"])
+        .to eql(user.id)
+      expect(result['_embedded']["experiment"]["id"])
+        .to eql(experiment.id)
+      expect(result['_embedded']["sample"]["id"])
+        .to eql(sample.id)
     end
 
     context 'with invalid/missing parameters' do 


### PR DESCRIPTION
- For relations that are collections we provide IDs and hrefs in `links`
- For relations that are singular, we embed the record in `_embedded`
- Better serialization for collections
  - Instead of creating two objects to GC at runtime for each collection, we create a specialized anonymous class for each relation then place it in a global cache.