### PR TITLE
145396445: CRUD tags on taggable

### DIFF
--- a/lib/api/endpoints/experiment.rb
+++ b/lib/api/endpoints/experiment.rb
@@ -21,7 +21,7 @@ module API
         )
 
         experiment.tags << declared_params[:tags]
-          .split(' ') if declared_params.key?(:tags)
+                           .split(' ') if declared_params.key?(:tags)
 
         Events::PostgresSink.call(experiment)
 

--- a/lib/api/endpoints/sample.rb
+++ b/lib/api/endpoints/sample.rb
@@ -29,7 +29,7 @@ module API
         )
 
         sample.tags << declared_params[:tags]
-          .split(' ') if declared_params.key?(:tags)
+                       .split(' ') if declared_params.key?(:tags)
 
         Events::PostgresSink.call(sample, :created)
         present(sample, with: Entities::Sample)

--- a/lib/api/endpoints/sample.rb
+++ b/lib/api/endpoints/sample.rb
@@ -13,6 +13,7 @@ module API
                         desc: 'audio sample, to be uploaded to s3'
         requires :low_label, type: String, desc: 'Label for low bound'
         requires :high_label, type: String, desc: 'Label for upper bound'
+        optional :tags, type: String, desc: 'Whitespace delimited list of tags'
       end
       put authorize: [:write, ::Sample] do
         status 201
@@ -23,9 +24,12 @@ module API
         )
 
         sample = ::Sample.create(
-          declared_hash.except(:file)
+          declared_hash.except(:file, :tags)
                        .merge(s3_key: s3_object.key, user_id: current_user.id)
         )
+
+        sample.tags << declared_params[:tags]
+          .split(' ') if declared_params.key?(:tags)
 
         Events::PostgresSink.call(sample, :created)
         present(sample, with: Entities::Sample)
@@ -75,12 +79,19 @@ module API
       params do
         requires :id, type: Integer, desc: 'ID of sample to be updated'
         optional :name, type: String, desc: 'Name of sample'
+        optional :tags, type: String, desc: 'Whitespace delimited tags'
       end
       post '/:id', authorize: [:write, ::Sample] do
         status 200
 
         sample = ::Sample.accessible_by(current_ability)
                          .find(declared_params[:id])
+
+        if declared_params.key?(:tags)
+          tags = declared_hash.delete(:tags).split(' ')
+          sample.tags >> (sample.tags.pluck(:name) - tags)
+          sample.tags << tags
+        end
 
         sample.update_attributes(declared_hash)
         Events::PostgresSink.call(sample)

--- a/lib/api/endpoints/user.rb
+++ b/lib/api/endpoints/user.rb
@@ -22,7 +22,7 @@ module API
         new_user.save(validate: false)
 
         new_user.tags << declared_params[:tags]
-          .split(' ') if declared_params.key?(:tags)
+                         .split(' ') if declared_params.key?(:tags)
 
         Events::PostgresSink.call(new_user)
         present(new_user, with: Entities::User)

--- a/lib/api/endpoints/user.rb
+++ b/lib/api/endpoints/user.rb
@@ -11,15 +11,18 @@ module API
         requires :email, type: String, desc: 'User email address'
         requires :encrypted_password, type: String,
                                       desc: 'BCrypt hash of user password'
+        optional :tags, type: String, desc: 'Whitespace delimited tags'
       end
       put authorize: [:write, ::User] do
         status 201
 
         # We skip validation because we require our clients
         # to compute the BCrypt hash.
-        new_user = ::User.new(declared(params).to_h)
+        new_user = ::User.new(declared_hash.except(:tags))
         new_user.save(validate: false)
-        new_user.reload
+
+        new_user.tags << declared_params[:tags]
+          .split(' ') if declared_params.key?(:tags)
 
         Events::PostgresSink.call(new_user)
         present(new_user, with: Entities::User)
@@ -65,10 +68,18 @@ module API
         optional :email, type: String, desc: 'User email address'
         optional :encrypted_password, type: String,
                                       desc: 'BCrypt hash of user password'
+        optional :tags, type: String, desc: 'Whitespace delimited tags'
       end
       post '/:id', authorize: [:write, ::User] do
         status 200
         user = ::User.accessible_by(current_ability).find(declared_params[:id])
+
+        if declared_params.key?(:tags)
+          tags = declared_hash.delete(:tags).split(' ')
+          user.tags >> (user.tags.pluck(:name) - tags)
+          user.tags << tags
+        end
+
         user.update_attributes(declared_hash)
         user.save
 


### PR DESCRIPTION
- Provide a whitespace delimited list of tags as a string to any taggable resource for `PUT` and `POST`