### PR TITLE
Kafka Producer Refactor

### DIFF
--- a/lib/api/endpoints/experiment.rb
+++ b/lib/api/endpoints/experiment.rb
@@ -23,7 +23,7 @@ module API
         experiment.tags << declared_params[:tags]
                            .split(' ') if declared_params.key?(:tags)
 
-        Events::PostgresSink.call(experiment)
+        Events::PostgresProducer.call(experiment)
 
         present(experiment, with: Entities::Experiment)
       end
@@ -67,7 +67,7 @@ module API
         status 204
 
         experiment = ::Experiment.find(declared_params[:id])
-        Events::PostgresSink.call(experiment, :destroyed)
+        Events::PostgresProducer.call(experiment, :destroyed)
         experiment.destroy!
 
         nil
@@ -115,7 +115,7 @@ module API
         end
 
         experiment.save
-        Events::PostgresSink.call(experiment)
+        Events::PostgresProducer.call(experiment)
 
         present(experiment, with: Entities::Experiment)
       end

--- a/lib/api/endpoints/organization.rb
+++ b/lib/api/endpoints/organization.rb
@@ -18,7 +18,7 @@ module API
         new_org.users << current_user
         new_org.save
 
-        Events::PostgresSink.call(new_org)
+        Events::PostgresProducer.call(new_org)
         present(new_org, with: Entities::Organization)
       end
 
@@ -89,7 +89,7 @@ module API
 
         org.save
 
-        Events::PostgresSink.call(org)
+        Events::PostgresProducer.call(org)
         present(org, with: Entities::Organization)
       end
 

--- a/lib/api/endpoints/sample.rb
+++ b/lib/api/endpoints/sample.rb
@@ -31,7 +31,7 @@ module API
         sample.tags << declared_params[:tags]
                        .split(' ') if declared_params.key?(:tags)
 
-        Events::PostgresSink.call(sample, :created)
+        Events::PostgresProducer.call(sample, :created)
         present(sample, with: Entities::Sample)
       end
 
@@ -68,7 +68,7 @@ module API
         status 204
 
         sample = ::Sample.find(declared_params[:id])
-        Events::PostgresSink.call(sample, :destroyed)
+        Events::PostgresProducer.call(sample, :destroyed)
         sample.destroy!
 
         nil
@@ -94,7 +94,7 @@ module API
         end
 
         sample.update_attributes(declared_hash)
-        Events::PostgresSink.call(sample)
+        Events::PostgresProducer.call(sample)
 
         present(sample, with: Entities::Sample)
       end

--- a/lib/api/endpoints/user.rb
+++ b/lib/api/endpoints/user.rb
@@ -24,7 +24,7 @@ module API
         new_user.tags << declared_params[:tags]
                          .split(' ') if declared_params.key?(:tags)
 
-        Events::PostgresSink.call(new_user)
+        Events::PostgresProducer.call(new_user)
         present(new_user, with: Entities::User)
       end
 
@@ -83,7 +83,7 @@ module API
         user.update_attributes(declared_hash)
         user.save
 
-        Events::PostgresSink.call(user)
+        Events::PostgresProducer.call(user)
         present(user, with: Entities::User)
       end
     end

--- a/lib/events.rb
+++ b/lib/events.rb
@@ -5,5 +5,5 @@ module Events
   autoload :Base
 
   autoload :EsManage
-  autoload :PostgresSink
+  autoload :PostgresProducer
 end

--- a/lib/events/postgres_producer/sample.rb
+++ b/lib/events/postgres_producer/sample.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+module Events
+  class PostgresProducer < Base
+    module Sample
+      def sample_created(model)
+        respond_to :sample_speech_recognition,
+                   message: model_base_message(model)
+      end
+
+      def sample_destroyed(model)
+        respond_to :sample_delete_from_s3,
+                   message: model_base_message(model)
+                     .merge(s3_key: model.s3_key)
+      end
+    end
+  end
+end

--- a/spec/lib/events/postgres_producer_spec.rb
+++ b/spec/lib/events/postgres_producer_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe Events::PostgresProducer do
+  context '#respond' do
+    let(:model) { FactoryGirl.create(:experiment) }
+
+    context 'defaults' do
+      after { subject.respond(model) }
+
+      it 'invokes the correct methods' do 
+        expect(described_class).to receive(:method_defined?)
+          .with("#{model.class.name.demodulize.underscore}_changed")
+          .and_call_original
+
+        allow(described_class).to receive(:method_defined?)
+          .with(:update_elasticsearch)
+
+        expect(subject).to receive(:update_elasticsearch).and_return(true)
+      end
+    end
+
+    context 'invokes the correct pipeline step, if present' do
+      let(:action) { :deleted }
+      let(:model_action) do
+        "#{model.class.name.demodulize.underscore}_#{action.to_s}"
+      end
+
+      it 'correctly checks for the action' do
+        expect(described_class).to receive(:method_defined?)
+          .with(model_action)
+          .and_return(true)
+
+        expect { subject.respond(model, action) }.to raise_error NoMethodError
+      end
+
+      context 'when the method is actually there' do
+        let(:model) { double }
+
+        before do
+          expect(model).to receive(:id).and_return(1)
+          allow(model)
+            .to receive_message_chain(*%i(class name demodulize underscore))
+            .and_return('foo')
+
+          described_class.include(Module.new do
+            def foo_deleted(_); end
+          end)
+        end
+
+        after { subject.respond(model, action) }
+
+        it 'will call foo_deleted' do
+          expect(described_class).to receive(:method_defined?)
+            .with(model_action)
+            .and_call_original
+
+          expect(subject).to receive(:foo_deleted)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Rename `PostgresSink` to `PostgresProducer` since that is what it's doing
- Break `Sample` lifecycle events into separate module
- Add test for `PostgresProducer`
