### PR TITLE
146587261: Refresh tokens, expiring access tokens. 

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -23,4 +23,9 @@ Doorkeeper.configure do
   class Doorkeeper::Application < ActiveRecord::Base
     belongs_to :user, class_name: ::User
   end 
+
+  # Access token behavior uses refresh tokens and 
+  # expires access tokens every two hours
+  access_token_expires_in 2.hours
+  use_refresh_token
 end


### PR DESCRIPTION
The `/oauth/token` endpoint now responds with this schema: 

```javascript
{
    "access_token": "67cb3340f0a0e47dab70ebd2a066dbca3c7f15bb35e02eb93782cacc706e3d3a",
    "token_type": "bearer",
    "expires_in": 7200,
    "refresh_token": "4f4ae864c5266037ae00063b93b2bd69104c9d626af2e91b4210ce661d82763f",
    "created_at": 1500768916
}
```